### PR TITLE
Revert "Making names better"

### DIFF
--- a/campaigns/_shadowrun_mecayotl/session_00.md
+++ b/campaigns/_shadowrun_mecayotl/session_00.md
@@ -7,22 +7,22 @@ date: 2026-05-03
 
 ## Saturday, January 11, 2086
 
-It was one of those Saturday nights where the ozone stings and the rain falls in sheets, making the AR billboards flicker and bleed into the gray sky. The crew had been sitting on their hoops for the better part of a month. You know the vibe, chummer, because the shadows go dead quiet right before the drek hits the fan. That was when <mark>Aleksy Gorka</mark>, a fixer who smells wetwork coming a mile away, lit up six commlinks at once.
+It was one of those Saturday nights where the ozone stings and the rain falls in sheets, making the AR billboards flicker and bleed into the gray sky. The crew had been sitting on their hoops for the better part of a month. You know the vibe, chummer, because the shadows go dead quiet right before the drek hits the fan. That was when `Aleksy Gorka`, a fixer who smells wetwork coming a mile away, lit up six commlinks at once.
 
 Quick roll call of where the biz caught the team:
 
-- <mark>Neon Ghost</mark> was over at Critical Hit Collectibles, killing time with some omaes among the toy shelves.
-- <mark>Sleeper</mark> was deep in the Dwarf Fortress. That is the old man's basement, just the way deckers like it: dark, cold, and full of cable.
-- <mark>NEEV</mark> was lounging in a crime boss's living room. She was trying to push through Submersion and, let's be real, failing hard. The resonance just wasn't flowing.
-- <mark>Toolbox</mark> had his hands deep in a Horizon Flying Eye. He was tuning rotors in the workshop like a wrench with a dream.
-- <mark>Bigoonia</mark> was in her element. She was feeding a rat to a venomous snake and playing shepherd to a menagerie that would make a Renraku bioweapons lab nervous.
-- <mark>Getafix</mark> was earning rent money pushing a DocWagon dispatch board on a freelance contract. He had one eye on the triage feed and the other eye on the clock.
+- **Neon Ghost** was over at Critical Hit Collectibles, killing time with some omaes among the toy shelves.
+- **Sleeper** was deep in the Dwarf Fortress. That is the old man's basement, just the way deckers like it: dark, cold, and full of cable.
+- **NEEV** was lounging in a crime boss's living room. She was trying to push through Submersion and, let's be real, failing hard. The resonance just wasn't flowing.
+- **Toolbox** had his hands deep in a Horizon Flying Eye. He was tuning rotors in the workshop like a wrench with a dream.
+- **Bigoonia** was in her element. She was feeding a rat to a venomous snake and playing shepherd to a menagerie that would make a Renraku bioweapons lab nervous.
+- **Getafix** was earning rent money pushing a DocWagon dispatch board on a freelance contract. He had one eye on the triage feed and the other eye on the clock.
 
-<mark>Aleksy's</mark> message was short because <mark>Aleksy's</mark> messages are always short: Johnson. Personnel problem. Time-sensitive. Thirty minutes. Four Floors, the table by the main bar. Suit up and don't be late.
+`Aleksy's` message was short because `Aleksy's` messages are always short: Johnson. Personnel problem. Time-sensitive. Thirty minutes. Four Floors, the table by the main bar. Suit up and don't be late.
 
 ## The Meet: The Man With The Skull Helmet
 
-`Four Floors`, the runners' favorite drekhole, hit them the way it always does — stale soykaf, cheap synthahol, top-40 synth-pop loud enough to rattle the fillings of anyone still running analog teeth. <mark>Bigoonia</mark> strolled up to the bar first and ordered herself a pink drink, all neon and pretty, before rolling over to the table like she owned the lease.
+`Four Floors`, the runners' favorite drekhole, hit them the way it always does — stale soykaf, cheap synthahol, top-40 synth-pop loud enough to rattle the fillings of anyone still running analog teeth. **Bigoonia** strolled up to the bar first and ordered herself a pink drink, all neon and pretty, before rolling over to the table like she owned the lease.
 
 The meeting went down with Mr. Johnson already at the table. He didn't come alone. He brought a troll so massive that his physical bulk actually eclipsed the AR ads as he pushed through the crowded shop. There was also a human in his shadow wearing enough chrome to start a recycling run. 
 
@@ -30,9 +30,9 @@ Mr. Johnson sat there in a suit that cost more than the team's last three runs c
 
 A PAN invite went out. A ¥ credstick icon appeared on the table, locked behind a little padlock until the crew took the job. Then the pitch:
 
-A **trideo** snapped up in AR. A corpwage named <mark>Gwendoline Perreault</mark> lifting paydata off a corporate terminal. Johnson wanted her **zeroed**. Wetwork. Robbery gone bad, shadow deal soured, *anything* but what it actually was: a corporate hit. And oh yeah she has a husband and a kid at home. She's supposed to be mundane, no chrome, no threat. *Their* problem was not Johnson's problem. Collateral was on the runners' dime.
+A **trideo** snapped up in AR. A corpwage named `Gwendoline Perreault` lifting paydata off a corporate terminal. Johnson wanted her **zeroed**. Wetwork. Robbery gone bad, shadow deal soured, *anything* but what it actually was: a corporate hit. And oh yeah she has a husband and a kid at home. She's supposed to be mundane, no chrome, no threat. *Their* problem was not Johnson's problem. Collateral was on the runners' dime.
 
-Then <mark>NEEV</mark> did what technomancers apparently do when they're not eating drek on Submersion tests: she negotiated. Hard. One-sided, the way a direct connect is one-sided. By the time the dust settled and Johnson's employer was paying what the crew was actually worth, the offer had climbed to **¥7,800 each**, with another **¥2,600 each** if they clawed back the paydata. Not bad for a few night's work in the Sixth World.
+Then `NEEV` did what technomancers apparently do when they're not eating drek on Submersion tests: she negotiated. Hard. One-sided, the way a direct connect is one-sided. By the time the dust settled and Johnson's employer was paying what the crew was actually worth, the offer had climbed to **¥7,800 each**, with another **¥2,600 each** if they clawed back the paydata. Not bad for a few night's work in the Sixth World.
 
 Job accepted. Credstick icon unlocked.
 
@@ -40,22 +40,22 @@ Job accepted. Credstick icon unlocked.
 
 First thing a professional crew does is not shoot anybody. First thing a professional crew does is **legwork**.
 
-<mark>Sleeper</mark> plugged in and went swimming. First he pulled the Mr. Johnson's trideo apart frame by frame, hunting for the kind of digital scar tissue that only a decker with a grudge against lies can spot, and found it. The footage was **doctored**, plain and simple. Somebody had edited <mark>Gwendoline</mark> into the scene like she was a badly-paid extra. Sleeper kept digging, and the Matrix gave it up: her home address, where she worked, the shift schedule that ran her week.
+`Sleeper` plugged in and went swimming. First he pulled the Mr. Johnson's trideo apart frame by frame, hunting for the kind of digital scar tissue that only a decker with a grudge against lies can spot, and found it. The footage was **doctored**, plain and simple. Somebody had edited `Gwendoline` into the scene like she was a badly-paid extra. Sleeper kept digging, and the Matrix gave it up: her home address, where she worked, the shift schedule that ran her week.
 
-<mark>Toolbox</mark> ran a parallel sweep and hit the uncomfortable kind of paydirt. He found leaked PHI sitting in a public node. It confirmed that <mark>Gwendoline</mark> was **Awakened**. She is a mage, an adept, or something else on that side of the veil. He also pulled a decent picture. That is worth more than a thousand lines of corp dossier when the knives come out.
+`Toolbox` ran a parallel sweep and hit the uncomfortable kind of paydirt. He found leaked PHI sitting in a public node. It confirmed that `Gwendoline` was **Awakened**. She is a mage, an adept, or something else on that side of the veil. He also pulled a decent picture. That is worth more than a thousand lines of corp dossier when the knives come out.
 
-<mark>NEEV</mark> tried to push her luck and compile a sprite to assist with the digging. What she got was a **dud**, a dribbly little resonance echo that couldn't find its own icon in a data grid. Back to the drawing board for her, at least for the moment.
+`NEEV` tried to push her luck and compile a sprite to assist with the digging. What she got was a **dud**, a dribbly little resonance echo that couldn't find its own icon in a data grid. Back to the drawing board for her, at least for the moment.
 
 ## The Stakeout: Eyes On the Mark
 
 With a name, a face, an address, and the uncomfortable knowledge that the target was Awakened and had a family at home, the crew rolled out to eyeball the apartment in person.
 
-Bright and early, <mark>Bigoonia</mark>, <mark>Toolbox</mark>, and <mark>Getafix</mark> loaded up and hit the street. They parked in a spot where it looked like nobody was parking. Then they watched from a spot where it looked like nobody was watching. It was standard ground-level coverage.
+Bright and early, `Bigoonia`, `Toolbox`, and `Getafix` loaded up and hit the street. They parked in a spot where it looked like nobody was parking. Then they watched from a spot where it looked like nobody was watching. It was standard ground-level coverage.
 
-<mark>Neon Ghost</mark> went vertical. He climbed to a rooftop across the way and lined up a sightline. He spotted her first and then flipped his sight into the **astral**. He **assensed** <mark>Gwendoline</mark> right through the window of her life. It was a perfect read. It was the kind of thing every mage brags about over synthahol later. He walked away knowing everything the meat wouldn't tell him. He saw the active spells, the shape of her magical signature, and the depth of her Awakening. He saw every bit of chrome she did or didn't have sunk under the skin. There were no implants to speak of. It was just her, her mojo, and the truth of it glowing clean.
+`Neon Ghost` went vertical. He climbed to a rooftop across the way and lined up a sightline. He spotted her first and then flipped his sight into the **astral**. He **assensed** `Gwendoline` right through the window of her life. It was a perfect read. It was the kind of thing every mage brags about over synthahol later. He walked away knowing everything the meat wouldn't tell him. He saw the active spells, the shape of her magical signature, and the depth of her Awakening. He saw every bit of chrome she did or didn't have sunk under the skin. There were no implants to speak of. It was just her, her mojo, and the truth of it glowing clean.
 
-That was when <mark>Bigoonia</mark> decided the night needed a little less watching and a little more *talking*. She is not exactly a subtle diplomat. 
+That was when `Bigoonia` decided the night needed a little less watching and a little more *talking*. She is not exactly a subtle diplomat. 
 
-She walked right up to <mark>Gwendoline</mark> on the street. It was a troll's worth of presence crowding a corpwage's personal space. She asked about the paydata like they were old friends catching up on gossip. <mark>Gwendoline</mark> did what any pro in her position would do. She played dumb. She acted like she didn't know what the trog was on about and just kept walking.
+She walked right up to `Gwendoline` on the street. It was a troll's worth of presence crowding a corpwage's personal space. She asked about the paydata like they were old friends catching up on gossip. `Gwendoline` did what any pro in her position would do. She played dumb. She acted like she didn't know what the trog was on about and just kept walking.
 
-<mark>Bigoonia</mark>, unsatisfied with the answer, **raised her voice.** Leaned in. Put the full weight of eight feet and several hundred kilos of intimidation on the street like a deployed riot baton.
+`Bigoonia`, unsatisfied with the answer, **raised her voice.** Leaned in. Put the full weight of eight feet and several hundred kilos of intimidation on the street like a deployed riot baton.


### PR DESCRIPTION
Reverts TabletopAdventures/tabletopadventures.github.io#25


This was, in fact, not better:
<img width="633" height="407" alt="image" src="https://github.com/user-attachments/assets/5913958c-392c-4a21-9e9e-9c0c3953e64f" />
